### PR TITLE
Fix line wrapping in preview mode

### DIFF
--- a/components/PublishedStep.tsx
+++ b/components/PublishedStep.tsx
@@ -80,7 +80,10 @@ class PublishedStep extends Component<PublishedStepProps, PublishedStepState> {
           {({ inView, ref, entry }) => (
             <div ref={ref} className={StepStyles[stepStyle]}>
               <h1>{index}</h1>
-              <div dangerouslySetInnerHTML={this.renderDraftJS()} />
+              <div
+                className={StepStyles["InnerHTML"]}
+                dangerouslySetInnerHTML={this.renderDraftJS()}
+              />
             </div>
           )}
         </InView>

--- a/styles/PublishedStep.module.scss
+++ b/styles/PublishedStep.module.scss
@@ -9,7 +9,7 @@
   border: 1px solid #edece9;
   border-radius: 8px;
   box-sizing: border-box;
-  color: #A1A19C;
+  color: #a1a19c;
 
   cursor: pointer;
 
@@ -19,4 +19,8 @@
     background: #ffffff;
     color: #000000;
   }
+}
+
+.InnerHTML {
+  word-break: break-all;
 }


### PR DESCRIPTION
<img width="1390" alt="Screen Shot 2020-06-28 at 11 39 05 AM" src="https://user-images.githubusercontent.com/11528318/85958423-50a60f00-b94a-11ea-9ed1-be9207c739ef.png">
becomes
<img width="645" alt="Screen Shot 2020-06-28 at 2 18 10 PM" src="https://user-images.githubusercontent.com/11528318/85958428-57cd1d00-b94a-11ea-8622-94750de7cd65.png">
