### PR TITLE
Fix finish post intro alignment + draft view code section alignment

### DIFF
--- a/components/CodeStepSection.tsx
+++ b/components/CodeStepSection.tsx
@@ -23,7 +23,7 @@ export default function CodeStepSection(props: {
   return (
     <div ref={ref} className={codeStepSectionStyles["codestep-section"]}>
       <CodeStepHeader />
-      <div className={codeStepSectionStyles["codestep-content"]}>
+      <div className={codeStepSectionStyles["draft-codestep-content"]}>
         <Publishing startIndex={startIndex} codeSteps={codeSteps} />
         <CodeEditor inView={inView} />
       </div>

--- a/styles/codestep.module.scss
+++ b/styles/codestep.module.scss
@@ -4,11 +4,24 @@
   // border: 1px solid black;
   display: flex;
   flex-direction: row-reverse;
+  padding-bottom: 40px;
 
   // margin-bottom: 64px;
   margin-right: 80px;
   // margin-right: 80px;
+  border-bottom: 1px solid $leaf-light-gray;
+  background-color: $leaf-background;
   margin-top: 64px;
+}
+
+.draft-codestep-content {
+  display: flex;
+  margin-top: 64px;
+  padding-bottom: 80px;
+
+  margin-right: 64px;
+  // margin-left: 40px;
+
 }
 
 @media only screen and (max-width: 600px) {
@@ -18,13 +31,6 @@
     margin-top: 0px !important;
     width: 100%;
   }
-}
-
-.codestep-section {
-  border-bottom: 1px solid $leaf-light-gray;
-  padding-bottom: 80px;
-  background-color: $leaf-background;
-  // background-color: #fafafa;
 }
 
 .divider {

--- a/styles/finishedpost.module.scss
+++ b/styles/finishedpost.module.scss
@@ -20,13 +20,16 @@
 
 .title {
   box-sizing: border-box;
-  padding-left: 16px;
-  padding-right: 16px;
+}
+
+@media only screen and (max-width: 800px) {
+  .title {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
 }
 
 .published-by {
-  padding-left: 16px;
-  padding-right: 16px;
   box-sizing: border-box;
   margin-top: 4px;
   //   padding: 4px;
@@ -38,6 +41,13 @@
   color: #757575;
   font-weight: 200;
   @include link-item;
+}
+
+@media only screen and (max-width: 800px) {
+  .published-by {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
 }
 
 @media only screen and (max-width: 600px) {


### PR DESCRIPTION
some css styling got broken in the finished post intro section and the draft view code step section because of the recent mobile changes. pushing this to fix
